### PR TITLE
Change generic method name to `jet_reconstruct`

### DIFF
--- a/examples/jetreco.jl
+++ b/examples/jetreco.jl
@@ -59,7 +59,7 @@ end
 """
 Top level call funtion for demonstrating the use of jet reconstruction
 
-This uses the "generic_jet_reconstruct" wrapper, so algorithm swutching
+This uses the "jet_reconstruct" wrapper, so algorithm switching
 happens inside the JetReconstruction package itself.
 
 Some other ustilities are also supported here, such as profiling and
@@ -88,19 +88,19 @@ function jet_process(
 	if nsamples > 1 || !isnothing(profile)
 		@info "Doing initial warm-up run"
 		for event in events
-			_ = inclusive_jets(generic_jet_reconstruct(event, R = distance, p = power, strategy = strategy), ptmin)
+			_ = inclusive_jets(jet_reconstruct(event, R = distance, p = power, strategy = strategy), ptmin)
 		end
 	end
 
 	if !isnothing(profile)
-		profile_code(profile, generic_jet_reconstruct, events, nsamples, R = distance, p = power, strategy = strategy)
+		profile_code(profile, jet_reconstruct, events, nsamples, R = distance, p = power, strategy = strategy)
 		return nothing
 	end
 
     if alloc
         println("Memory allocation statistics:")
         @timev for event in events
-			_ = inclusive_jets(generic_jet_reconstruct(event, R = distance, p = power, strategy = strategy), ptmin)
+			_ = inclusive_jets(jet_reconstruct(event, R = distance, p = power, strategy = strategy), ptmin)
         end
         return nothing
     end
@@ -114,7 +114,7 @@ function jet_process(
 		gcoff && GC.enable(false)
 		t_start = time_ns()
 		for (ievt, event) in enumerate(events)
-			finaljets = inclusive_jets(generic_jet_reconstruct(event, R = distance, p = power, strategy = strategy), ptmin)
+			finaljets = inclusive_jets(jet_reconstruct(event, R = distance, p = power, strategy = strategy), ptmin)
 			# Only print the jet content once
 			if irun == 1
 				@info begin

--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -76,25 +76,6 @@ struct ClusterSequence
     Qtot
 end
 
-"""Return all inclusive jets of a ClusterSequence with pt > ptmin"""
-function inclusive_jets(clusterseq::ClusterSequence, ptmin = 0.0)
-    dcut = ptmin * ptmin
-    jets_local = Vector{LorentzVectorCyl}(undef, 0)
-    # sizehint!(jets_local, length(clusterseq.jets))
-    # For inclusive jets with a plugin algorithm, we make no
-    # assumptions about anything (relation of dij to momenta,
-    # ordering of the dij, etc.)
-    # for elt in Iterators.reverse(clusterseq.history)
-    for elt in clusterseq.history
-        elt.parent2 == BeamJet || continue
-        iparent_jet = clusterseq.history[elt.parent1].jetp_index
-        jet = clusterseq.jets[iparent_jet]
-        if pt2(jet) >= dcut
-            push!(jets_local, LorentzVectorCyl(pt(jet), rapidity(jet), phi(jet), mass(jet)))
-        end
-    end
-    jets_local
-end
 
 """Add a new jet's history into the recombination sequence"""
 add_step_to_history!(clusterseq::ClusterSequence, parent1, parent2, jetp_index, dij) = begin
@@ -133,3 +114,24 @@ add_step_to_history!(clusterseq::ClusterSequence, parent1, parent2, jetp_index, 
         clusterseq.jets[jetp_index]._cluster_hist_index = local_step
     end
 end
+
+"""Return all inclusive jets of a ClusterSequence with pt > ptmin"""
+function inclusive_jets(clusterseq::ClusterSequence, ptmin = 0.0)
+    dcut = ptmin * ptmin
+    jets_local = Vector{LorentzVectorCyl}(undef, 0)
+    # sizehint!(jets_local, length(clusterseq.jets))
+    # For inclusive jets with a plugin algorithm, we make no
+    # assumptions about anything (relation of dij to momenta,
+    # ordering of the dij, etc.)
+    # for elt in Iterators.reverse(clusterseq.history)
+    for elt in clusterseq.history
+        elt.parent2 == BeamJet || continue
+        iparent_jet = clusterseq.history[elt.parent1].jetp_index
+        jet = clusterseq.jets[iparent_jet]
+        if pt2(jet) >= dcut
+            push!(jets_local, LorentzVectorCyl(pt(jet), rapidity(jet), phi(jet), mass(jet)))
+        end
+    end
+    jets_local
+end
+

--- a/src/GenericAlgo.jl
+++ b/src/GenericAlgo.jl
@@ -2,7 +2,7 @@
 # switch based on the strategy, or based on the event density
 # if the "Best" strategy is to be employed
 
-function generic_jet_reconstruct(particles; p = -1, R = 1.0, recombine = +, strategy = JetRecoStrategy.Best)
+function jet_reconstruct(particles; p = -1, R = 1.0, recombine = +, strategy = JetRecoStrategy.Best)
     # Either map to the fixed algorithm corresponding to the strategy
     # or to an optimal choice based on the density of initial particles
 

--- a/src/JetReconstruction.jl
+++ b/src/JetReconstruction.jl
@@ -48,7 +48,7 @@ export tiled_jet_reconstruct
 
 ## Generic algorithm, which can switch strategy dynamically
 include("GenericAlgo.jl")
-export generic_jet_reconstruct
+export jet_reconstruct
 
 # Simple HepMC3 reader
 include("HepMC3.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,9 @@ function do_test_compare_to_fastjet(strategy::JetRecoStrategy.Strategy, fastjet_
     elseif (strategy == JetRecoStrategy.N2Tiled)
         jet_reconstruction = tiled_jet_reconstruct
         strategy_name = "N2Tiled"
+    elseif (strategy == JetRecoStrategy.Best)
+        jet_reconstruction = jet_reconstruct
+        strategy_name = "Best"
     else
         throw(ErrorException("Strategy not yet implemented"))
     end


### PR DESCRIPTION
There is no need to have the prefix `generic` on the main interface, it's simpler just to call it `jet_reconstruct`.

Update the README to show how to run reconstruction using the "Best" strategy (this is the default way).

Add also a note on sorting (which is super trivial in Julia, so no need to support specific methods for
`Vector{PseudoJet}` as fastjet does).