### PR TITLE
Fix plotting for `ClusterSequence` and update serialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ The example also shows how to use `JetReconstruction.HepMC3` to read HepMC3 ASCI
 
 ### Plotting
 
-**TO BE FIXED**
-
 ![illustration](img/illustration.jpeg)
 
 To visualise the clustered jets as a 3d bar plot (see illustration above) we now use `Makie.jl`. See the `jetsplot` function and its documentation for more. 
+
+### Serialisation
+
+The package also provides methods such as `loadjets`, `loadjets!`, and `savejets` that one can use to save and load objects on/from disk easily in a very flexible format. See documentation for more.
 
 ## Reference
 

--- a/src/JetVis.jl
+++ b/src/JetVis.jl
@@ -88,7 +88,7 @@ function jetsplot(objects, idx_arrays; barsize_phi=0.1, barsize_eta=0.1, colorma
 		cs[j] = i
 	end
 
-	pts = pt2.(objects)
+	pts = sqrt.(pt2.(objects))
 
 	Module.meshscatter(
 		Module.Point3f.(phi.(objects), rapidity.(objects), 0pts);

--- a/src/Serialize.jl
+++ b/src/Serialize.jl
@@ -35,7 +35,7 @@ function savejets(filename, jets; format="px py pz E")
 end
 
 """
-    loadjets!(filename, jets; splitby=isspace, constructor=(x,y,z,E)->LorentzVector(E,px,py,pz), dtype=Float64) -> jets
+    loadjets!(filename, jets; splitby=isspace, constructor=(px,py,pz,E)->LorentzVector(E,px,py,pz), dtype=Float64)
 
 Loads the `jets` from a file. Ignores lines that start with `'#'`. Each line gets processed in the following way: the line is split using `split(line, splitby)` or simply `split(line)` by default. Every value in this line is then converted to the `dtype` (which is `Float64` by default). These values are then used as arguments for the `constructor` function which should produce individual jets. By default, the `constructor` constructs Lorentz vectors.
 
@@ -47,7 +47,7 @@ loadjets!("myjets1.dat", jets)
 loadjets!("myjets2.dat", jets)
 ```
 """
-function loadjets!(filename, jets; splitby=isspace, constructor=(x,y,z,E)->LorentzVector(E,px,py,pz), dtype=Float64)
+function loadjets!(filename, jets; splitby=isspace, constructor=(px,py,pz,E)->LorentzVector(E,px,py,pz), dtype=Float64)
     open(filename, "r") do file
         for line in eachline(file)
             if line[1] != '#'

--- a/src/Serialize.jl
+++ b/src/Serialize.jl
@@ -1,19 +1,17 @@
 """
 `savejets(filename, jets; format="px py pz E")`
 
-Saves the given `jets` into a file with the given `filename`. Each line contains information about a single jet and is formatted according to the `format` string which defaults to `"px py pz E"` but can also contain other values in any order: `"pt2"` or `"kt"` for transverse momentum, `"phi"` for azimuth, `"eta"` or `"rapidity"` for pseudorapidity, `"m"` for mass. It is strongly NOT recommended to put something other than values and (possibly custom) separators in the `format` string.
+Saves the given `jets` into a file with the given `filename`. Each line contains information about a single jet and is formatted according to the `format` string which defaults to `"px py pz E"` but can also contain other values in any order: `"pt2"` for pt^2, `"phi"` for azimuth, `"rapidity"` for rapidity. It is strongly NOT recommended to put something other than values and (possibly custom) separators in the `format` string.
 """
 function savejets(filename, jets; format="px py pz E")
     symbols = Dict(
         "E" => JetReconstruction.energy,
+        "energy" => JetReconstruction.energy,
         "px" => JetReconstruction.px,
-        "pt2" => JetReconstruction.pt2,
-        "kt" => JetReconstruction.pt2,
         "py" => JetReconstruction.py,
         "pz" => JetReconstruction.pz,
+        "pt2" => JetReconstruction.pt2,
         "phi" => JetReconstruction.phi,
-        "m" => JetReconstruction.mass,
-        "eta" => JetReconstruction.rapidity,
         "rapidity" => JetReconstruction.rapidity
     )
     for pair in symbols
@@ -23,7 +21,7 @@ function savejets(filename, jets; format="px py pz E")
     end
 
     open(filename, "w") do file
-        write(file, "# this file contains jet data.\n# each line that does not start with '#' contains the information about a jet in the following format:\n# "*"$(format)"*"\n# where E is energy, px is momentum along x, py is momentum along y, pz is momentum along z, pt or kt is transverse momentum, phi is azimuth, eta is pseudorapidity, m is mass\n")
+        write(file, "# this file contains jet data.\n# each line that does not start with '#' contains the information about a jet in the following format:\n# "*"$(format)"*"\n# where E is energy, px is momentum along x, py is momentum along y, pz is momentum along z, pt2 is pt^2, phi is azimuth, and rapidity is rapidity\n")
         for j in jets
             line = format
             for pair in symbols
@@ -67,7 +65,7 @@ end
 """
     loadjets(filename; splitby=isspace, constructor=(px,py,pz,E)->LorentzVector(E,px,py,pz), VT=LorentzVector) -> jets
 
-Loads the `jets` from a file, where each element of `jets` is of type `VT`. Ignores lines that start with `'#'`. Each line gets processed in the following way: the line is split using `split(line, splitby)` or simply `split(line)` by default. These values are then used as arguments for the `constructor` function which should produce individual jets. By default, the `constructor` constructs Lorentz vectors.
+Loads the `jets` from a file, where each element of `jets` is of type `VT`. Ignores lines that start with `'#'`. Each line gets processed in the following way: the line is split using `split(line, splitby)` or simply `split(line)` by default. These values are then used as arguments for the `constructor` function which should produce individual jets of the `VT` type. By default, the `constructor` constructs Lorentz vectors.
 
 ```julia
 # example


### PR DESCRIPTION
This PR tackles the issue #43 by implementing an additional variant of the `jetsplot` function that works with `ClusterSequence` on top of the existing old one that has been developed in 2022 at the beginning of the project. Additionally, I have updated the serialisation methods, as they were partially deprecated and `savejets` was incompatible with the new things in the repository.