### PR TITLE
Optimise e+e- reconstruction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 LorentzVectorHEP = "f612022c-142a-473f-8cfd-a09cf3793c6c"
 LorentzVectors = "3f54b04b-17fc-5cd4-9758-90c048d965e3"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
+StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 
 [weakdeps]
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
@@ -30,6 +31,7 @@ LorentzVectorHEP = "0.1.6"
 LorentzVectors = "0.4.3"
 Makie = "0.21"
 MuladdMacro = "0.2.4"
+StructArrays = "0.6.18"
 julia = "1.9"
 
 [extras]

--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -176,6 +176,8 @@ add_step_to_history!(clusterseq::ClusterSequence, parent1, parent2, jetp_index, 
 
     local_step = length(clusterseq.history)
 
+    # println("Adding step $local_step: parent1=$parent1, parent2=$parent2, jetp_index=$jetp_index, dij=$dij")
+
     # Sanity check: make sure the particles have not already been recombined
     #
     # Note that good practice would make this an assert (since this is
@@ -184,7 +186,10 @@ add_step_to_history!(clusterseq::ClusterSequence, parent1, parent2, jetp_index, 
     # retry the clustering with a different strategy.
     @assert parent1 >= 1
     if clusterseq.history[parent1].child != Invalid
-        error("Internal error. Trying to recombine an object that has previsously been recombined.")
+        error("Internal error. Trying to recombine an object that has previsously been recombined. Parent " *
+              string(parent1) * "'s child index " *
+              string(clusterseq.history[parent1].child) * ". Parent jet index: " *
+              string(clusterseq.history[parent1].jetp_index) * ".")
     end
 
     hist_elem = clusterseq.history[parent1]

--- a/src/EEAlgorithm.jl
+++ b/src/EEAlgorithm.jl
@@ -58,7 +58,7 @@ function get_angular_nearest_neighbours!(eereco, algorithm, dij_factor)
             eereco.nndist[i] = better_nndist_i ? this_nndist : eereco.nndist[i]
             eereco.nni[i] = better_nndist_i ? j : eereco.nni[i]
             better_nndist_j = this_nndist < eereco[j].nndist
-            eereco.nndist[j] = better_nndist_j ? this_nndist : eereco.nndist[i]
+            eereco.nndist[j] = better_nndist_j ? this_nndist : eereco.nndist[j]
             eereco.nni[j] = better_nndist_j ? i : eereco.nni[j]
             # if this_nndist < eereco[i].nndist
             #     eereco.nndist[i] = this_nndist

--- a/src/EEAlgorithm.jl
+++ b/src/EEAlgorithm.jl
@@ -72,7 +72,7 @@ end
 function get_angular_nearest_neighbours!(eereco, algorithm, dij_factor)
     # Get the initial nearest neighbours for each jet
     N = length(eereco)
-    this_dist_vector = Vector{Float64}(undef, N)
+    # this_dist_vector = Vector{Float64}(undef, N)
     # Nearest neighbour geometric distance
     @inbounds for i in 1:N
         # TODO: Replace the 'j' loop with a vectorised operation over the appropriate array elements
@@ -80,14 +80,20 @@ function get_angular_nearest_neighbours!(eereco, algorithm, dij_factor)
         #     eereco[i].ny .* eereco[i + 1:end].ny .- eereco[i].nz .* eereco[i + 1:end].nz
         @inbounds for j in (i + 1):N
             @muladd this_nndist = 1.0 - eereco[i].nx * eereco[j].nx - eereco[i].ny * eereco[j].ny - eereco[i].nz * eereco[j].nz
-            if this_nndist < eereco[i].nndist
-                eereco.nndist[i] = this_nndist
-                eereco.nni[i] = j
-            end
-            if this_nndist < eereco[j].nndist
-                eereco.nndist[j] = this_nndist
-                eereco.nni[j] = i
-            end
+            better_nndist_i = this_nndist < eereco[i].nndist
+            eereco.nndist[i] = better_nndist_i ? this_nndist : eereco.nndist[i]
+            eereco.nni[i] = better_nndist_i ? j : eereco.nni[i]
+            better_nndist_j = this_nndist < eereco[j].nndist
+            eereco.nndist[j] = better_nndist_j ? this_nndist : eereco.nndist[i]
+            eereco.nni[j] = better_nndist_j ? i : eereco.nni[j]
+            # if this_nndist < eereco[i].nndist
+            #     eereco.nndist[i] = this_nndist
+            #     eereco.nni[i] = j
+            # end
+            # if this_nndist < eereco[j].nndist
+            #     eereco.nndist[j] = this_nndist
+            #     eereco.nni[j] = i
+            # end
         end
     end
     # Nearest neighbour dij distance

--- a/src/EEAlgorithm.jl
+++ b/src/EEAlgorithm.jl
@@ -104,10 +104,13 @@ function get_angular_nearest_neighbours!(eereco, algorithm, dij_factor)
     # This is structured to only check for EEKt once!
     if algorithm == JetAlgorithm.EEKt
         @inbounds for i in 1:N
-            if eereco[i].E2p < eereco[i].dijdist
-                eereco.dijdist[i] = eereco.E2p[i]
-                eereco.nni[i] = 0
-            end
+            beam_close = eereco[i].E2p < eereco[i].dijdist
+            eereco.dijdist[i] = beam_close ? eereco[i].E2p : eereco.dijdist[i]
+            eereco.nni[i] = beam_close ? 0 : eereco.nni[i]
+            # if eereco[i].E2p < eereco[i].dijdist
+            #     eereco.dijdist[i] = eereco.E2p[i]
+            #     eereco.nni[i] = 0
+            # end
         end
     end
 end
@@ -139,18 +142,24 @@ function update_nn_no_cross!(eereco, i, N, algorithm, dij_factor)
     @inbounds for j in 1:N
         if j != i
             @muladd this_nndist = 1.0 - eereco[i].nx * eereco[j].nx - eereco[i].ny * eereco[j].ny - eereco[i].nz * eereco[j].nz
-            if this_nndist < eereco[i].nndist
-                eereco.nndist[i] = this_nndist
-                eereco.nni[i] = j
-            end
+            better_nndist_i = this_nndist < eereco[i].nndist
+            eereco.nndist[i] = better_nndist_i ? this_nndist : eereco.nndist[i]
+            eereco.nni[i] = better_nndist_i ? j : eereco.nni[i]
+            # if this_nndist < eereco[i].nndist
+            #     eereco.nndist[i] = this_nndist
+            #     eereco.nni[i] = j
+            # end
         end
     end
     eereco.dijdist[i] = min(eereco[i].E2p, eereco[eereco[i].nni].E2p) * dij_factor * eereco[i].nndist
     if algorithm == JetAlgorithm.EEKt
-        if eereco[i].E2p < eereco[i].dijdist
-            eereco.dijdist[i] = eereco[i].E2p
-            eereco.nni[i] = 0
-        end
+        beam_close = eereco[i].E2p < eereco[i].dijdist
+        eereco.dijdist[i] = beam_close ? eereco[i].E2p : eereco.dijdist[i]
+        eereco.nni[i] = beam_close ? 0 : eereco.nni[i]
+        # if eereco[i].E2p < eereco[i].dijdist
+        #     eereco.dijdist[i] = eereco[i].E2p
+        #     eereco.nni[i] = 0
+        # end
     end
 end
 
@@ -190,10 +199,13 @@ function update_nn_cross!(eereco, i, N, algorithm, dij_factor)
     @inbounds for j in 1:N
         if j != i
             @muladd this_nndist = 1.0 - eereco[i].nx * eereco[j].nx - eereco[i].ny * eereco[j].ny - eereco[i].nz * eereco[j].nz
-            if this_nndist < eereco[i].nndist
-                eereco.nndist[i] = this_nndist
-                eereco.nni[i] = j
-            end
+            better_nndist_i = this_nndist < eereco[i].nndist
+            eereco.nndist[i] = better_nndist_i ? this_nndist : eereco.nndist[i]
+            eereco.nni[i] = better_nndist_i ? j : eereco.nni[i]
+            # if this_nndist < eereco[i].nndist
+            #     eereco.nndist[i] = this_nndist
+            #     eereco.nni[i] = j
+            # end
             if this_nndist < eereco[j].nndist
                 eereco.nndist[j] = this_nndist
                 eereco.nni[j] = i
@@ -210,10 +222,13 @@ function update_nn_cross!(eereco, i, N, algorithm, dij_factor)
     end
     eereco.dijdist[i] = min(eereco[i].E2p, eereco[eereco[i].nni].E2p) * dij_factor * eereco[i].nndist
     if algorithm == JetAlgorithm.EEKt
-        if eereco[i].E2p < eereco[i].dijdist
-            eereco.dijdist[i] = eereco[i].E2p
-            eereco.nni[i] = 0
-        end
+        beam_close = eereco[i].E2p < eereco[i].dijdist
+        eereco.dijdist[i] = beam_close ? eereco[i].E2p : eereco.dijdist[i]
+        eereco.nni[i] = beam_close ? 0 : eereco.nni[i]
+        # if eereco[i].E2p < eereco[i].dijdist
+        #     eereco.dijdist[i] = eereco[i].E2p
+        #     eereco.nni[i] = 0
+        # end
     end
 end
 

--- a/src/EEjet.jl
+++ b/src/EEjet.jl
@@ -11,30 +11,21 @@ The `EEjet` struct is a 4-momentum object used for the e+e jet reconstruction ro
 - `_cluster_hist_index::Int`: The index of the cluster histogram.
 - `_p2::Float64`: The squared momentum of the jet.
 - `_inv_p::Float64`: The inverse momentum of the jet.
-- `_nx::Float64`: The normalised x-component of the jet direction [0.0, 1.0].
-- `_ny::Float64`: The normalised y-component of the jet direction [0.0, 1.0].
-- `_nz::Float64`: The normalised z-component of the jet direction [0.0, 1.0].
 """
 mutable struct EEjet <: FourMomentum
     px::Float64
     py::Float64
     pz::Float64
     E::Float64
-    _cluster_hist_index::Int
     _p2::Float64
     _inv_p::Float64
-    _nx::Float64
-    _ny::Float64
-    _nz::Float64
+    _cluster_hist_index::Int
 end
 
 function EEjet(px::Float64, py::Float64, pz::Float64, E::Float64, _cluster_hist_index::Int)
     @muladd p2 = px * px + py * py + pz * pz
-    inv_p = 1.0 / sqrt(p2)
-    nx = px * inv_p
-    ny = py * inv_p
-    nz = pz * inv_p
-    EEjet(px, py, pz, E, _cluster_hist_index, p2, inv_p, nx, ny, nz)
+    inv_p = @fastmath 1.0 / sqrt(p2)
+    EEjet(px, py, pz, E, p2, inv_p, _cluster_hist_index)
 end
 
 EEjet(px::Float64, py::Float64, pz::Float64, E::Float64) = EEjet(px, py, pz, E, 0)
@@ -49,9 +40,9 @@ energy(eej::EEjet) = eej.E
 px(eej::EEjet) = eej.px
 py(eej::EEjet) = eej.py
 pz(eej::EEjet) = eej.pz
-nx(eej::EEjet) = eej._nx
-ny(eej::EEjet) = eej._ny
-nz(eej::EEjet) = eej._nz
+nx(eej::EEjet) = eej.px * eej._inv_p
+ny(eej::EEjet) = eej.py * eej._inv_p
+nz(eej::EEjet) = eej.pz * eej._inv_p
 cluster_hist_index(eej::EEjet) = eej._cluster_hist_index
 
 phi(eej::EEjet) = begin

--- a/src/EEjet.jl
+++ b/src/EEjet.jl
@@ -95,3 +95,16 @@ function show(io::IO, eej::EEjet)
     print(io, "EEjet(px: ", eej.px, " py: ", eej.py, " pz: ", eej.pz, " E: ", eej.E,
           " cluster_hist_index: ", eej._cluster_hist_index, ")")
 end
+
+# Optimised reconstruction struct for e+e jets
+
+mutable struct EERecoJet
+    index::Int
+    nni::Int
+    nndist::Float64
+    dijdist::Float64
+    nx::Float64
+    ny::Float64
+    nz::Float64
+    E2p::Float64
+end

--- a/src/JetReconstruction.jl
+++ b/src/JetReconstruction.jl
@@ -17,6 +17,7 @@ module JetReconstruction
 
 using LorentzVectorHEP
 using MuladdMacro
+using StructArrays
 
 # Import from LorentzVectorHEP methods for those 4-vector types
 pt2(p::LorentzVector) = LorentzVectorHEP.pt2(p)


### PR DESCRIPTION
Change the strategy for e+e- algorithms to hold all variables used in the repo calculations in a *structure of arrays*. This is achieved using a `struct` to hold the relevant variables per particle and the `StructArrays` package being used to generate the SoA structure from this for the reconstruction.

The speed-up is significant, approximately 40% of the original speed (this varies, based on the `R` parameter).

Significant refactoring of the implementation of the distance and metric distance calculation is done to use the new structures.