### PR TITLE
fix typos in comments and docstrings

### DIFF
--- a/examples/instrumented-jetreco.jl
+++ b/examples/instrumented-jetreco.jl
@@ -59,12 +59,12 @@ function profile_code(profile, jet_reconstruction, events, niters; R = 0.4, p = 
             """)
 end
 """
-Top level call funtion for demonstrating the use of jet reconstruction
+Top level call function for demonstrating the use of jet reconstruction
 
 This uses the "jet_reconstruct" wrapper, so algorithm switching
 happens inside the JetReconstruction package itself.
 
-Some other ustilities are also supported here, such as profiling and
+Some other utilities are also supported here, such as profiling and
 serialising the reconstructed jet outputs.
 """
 function jet_process(events::Vector{Vector{T}};

--- a/examples/jetreco.jl
+++ b/examples/jetreco.jl
@@ -16,7 +16,7 @@ using JetReconstruction
 include(joinpath(@__DIR__, "parse-options.jl"))
 
 """
-Top level call funtion for demonstrating the use of jet reconstruction
+Top level call function for demonstrating the use of jet reconstruction
 
 This uses the "jet_reconstruct" wrapper, so algorithm switching
 happens inside the JetReconstruction package itself.

--- a/examples/parse-options.jl
+++ b/examples/parse-options.jl
@@ -1,5 +1,5 @@
 """
-Add `parse_item` code for interpeting `JetAlgorithm.Algorithm` and `RecoStrategy.Strategy` types
+Add `parse_item` code for interpreting `JetAlgorithm.Algorithm` and `RecoStrategy.Strategy` types
 from the command line.
 """
 

--- a/ext/JetVisualisation.jl
+++ b/ext/JetVisualisation.jl
@@ -52,8 +52,8 @@ end
     jetsplot(objects, idx_arrays; barsize_phi=0.1, barsize_eta=0.1, colormap=:glasbey_hv_n256, Module=Main)
 
 Plots a 3d bar chart that represents jets. Takes an `objects` array of objects
-to display and `idx_arrays`, an array of arrays with indeces, where
-`idx_arrays[i]` gives indeces of `objects` that form the jet number `i`. This
+to display and `idx_arrays`, an array of arrays with indices, where
+`idx_arrays[i]` gives indices of `objects` that form the jet number `i`. This
 function's signature might not be the most practical for the current version of
 the JetReconstruction.jl package, as it has been written during the early stage
 of development. There is now an overload of it that takes a `ClusterSequence`
@@ -225,7 +225,7 @@ function JetReconstruction.animatereco(cs::ClusterSequence, filename;
     merge_steps = JetReconstruction.merge_steps(cs)
     jet_ranks = JetReconstruction.jet_ranks(cs)
 
-    # End point of the catagorical color map
+    # End point of the categorical color map
     # (How to get this programmatically from the CM Symbol?)
     colormap_end = 256
 

--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -187,7 +187,7 @@ add_step_to_history!(clusterseq::ClusterSequence, parent1, parent2, jetp_index, 
     # retry the clustering with a different strategy.
     @assert parent1 >= 1
     if clusterseq.history[parent1].child != Invalid
-        error("Internal error. Trying to recombine an object that has previsously been recombined. Parent " *
+        error("Internal error. Trying to recombine an object that has previously been recombined. Parent " *
               string(parent1) * "'s child index " *
               string(clusterseq.history[parent1].child) * ". Parent jet index: " *
               string(clusterseq.history[parent1].jetp_index) * ".")
@@ -198,7 +198,7 @@ add_step_to_history!(clusterseq::ClusterSequence, parent1, parent2, jetp_index, 
 
     if parent2 >= 1
         clusterseq.history[parent2].child == Invalid ||
-            error("Internal error. Trying to recombine an object that has previsously been recombined.  Parent " *
+            error("Internal error. Trying to recombine an object that has previously been recombined.  Parent " *
                   string(parent2) * "'s child index " *
                   string(clusterseq.history[parent1].child) * ". Parent jet index: " *
                   string(clusterseq.history[parent2].jetp_index) * ".")
@@ -363,7 +363,7 @@ Return the number of exclusive jets of a ClusterSequence that are above a certai
 
 # Arguments
 - `clusterseq::ClusterSequence`: The `ClusterSequence` object containing the clustering history.
-- `dcut::AbstractFloat`: The maximum calue for the distance parameter in the reconstruction.
+- `dcut::AbstractFloat`: The maximum value for the distance parameter in the reconstruction.
 
 # Returns
 The number of exclusive jets in the `ClusterSequence` object.

--- a/src/GenericAlgo.jl
+++ b/src/GenericAlgo.jl
@@ -33,7 +33,7 @@ these methods are already predefined in the `JetReconstruction` namespace.
 The `recombine` argument is the function used to merge pairs of particles. The
 default is simply `+(jet1,jet2)`, i.e. 4-momenta addition or the *E*-scheme.
 
-## Consitency of `p`, `algorithm` and `R` arguments
+## Consistency of `p`, `algorithm` and `R` arguments
 If an algorithm is explicitly specified the `p` value should be consistent with
 it or `nothing`. If the algorithm is one where `p` can vary, then it has to be
 given, along with the algorithm.``

--- a/src/HepMC3.jl
+++ b/src/HepMC3.jl
@@ -71,7 +71,7 @@ Particle{T}() where {T} = Particle(LorentzVector{T}(0.0, 0.0, 0.0, 0.0), 0, 0, 0
 """ Read a [HepMC3](https://doi.org/10.1016/j.cpc.2020.107310) ascii file.
 
     Each event is passed to the provided function f as a vector of Particles. A
-    maximum number of events to read (value -1 to read all availble events) and
+    maximum number of events to read (value -1 to read all available events) and
     a number of events to skip at the beginning of the file can be provided.
 """
 

--- a/src/PlainAlgo.jl
+++ b/src/PlainAlgo.jl
@@ -136,7 +136,7 @@ Arguments:
 - `j`: Index of the second particle in the last merge step.
 - `k`: Index of the current particle for which the nearest neighbour will be
   updated.
-- `N`: Total number of particles (currently vaild array indexes are `[1:N]`).
+- `N`: Total number of particles (currently valid array indexes are `[1:N]`).
 - `Nn`: Number of nearest neighbors to consider.
 - `kt2_array`: Array of transverse momentum squared values.
 - `rapidity_array`: Array of rapidity values.

--- a/src/Pseudojet.jl
+++ b/src/Pseudojet.jl
@@ -21,7 +21,7 @@ const _invalid_rap = -1.e200
     mutable struct PseudoJet <: FourMomentum
 
 The `PseudoJet` struct represents a pseudojet, a four-momentum object used in
-jet reconstruction algorithms. Additonal information for the link back into the
+jet reconstruction algorithms. Additional information for the link back into the
 history of the clustering is stored in the `_cluster_hist_index` field. There is
 caching of the more expensive calculations for rapidity and azimuthal angle.
 

--- a/src/TiledAlgoLL.jl
+++ b/src/TiledAlgoLL.jl
@@ -106,7 +106,7 @@ tiledjet_set_jetinfo!(jet::TiledJet, clusterseq::ClusterSequence, tiling::Tiling
     jet.NN_dist = R2
     jet.NN = noTiledJet
 
-    # Find out which tile it belonds to
+    # Find out which tile it belongs to
     jet.tile_index = tile_index(tiling.setup, jet.eta, jet.phi)
 
     # Insert it into the tile's linked list of jets (at the beginning)
@@ -333,7 +333,7 @@ end
     tiled_jet_reconstruct(particles::Vector{T}; p = -1, R = 1.0, recombine = +) where {T}
 
 Main jet reconstruction algorithm entry point for reconstructing jets using the
-tiled stragegy for generic jet type T.
+tiled strategy for generic jet type T.
 
 **Note** - if a non-standard recombination is used, it must be defined for
 JetReconstruction.PseudoJet, as this struct is used internally.
@@ -349,7 +349,7 @@ If both are given they must be consistent or an exception is thrown.
   reconstruction. T must support methods px, py, pz and energy (defined in the
   JetReconstruction namespace)
 - `p::Union{Real, Nothing} = -1`: The power parameter for the jet reconstruction
-  algorithm, thus swiching between different algorithms.
+  algorithm, thus switching between different algorithms.
 - `algorithm::Union{JetAlgorithm, Nothing} = nothing`: The explicit jet
   algorithm to use.
 - `R::Float64 = 1.0`: The jet radius parameter for the jet reconstruction
@@ -407,7 +407,7 @@ of data types are done.
 - `particles::Vector{PseudoJet}`: A vector of `PseudoJet` particles used as input for jet
   reconstruction.
 - `p::Int = -1`: The power parameter for the jet reconstruction algorithm, thus
-  swiching between different algorithms.
+  switching between different algorithms.
 - `R::Float64 = 1.0`: The jet radius parameter for the jet reconstruction
   algorithm.
 - `recombine::Function = +`: The recombination function used for combining
@@ -473,7 +473,7 @@ function _tiled_jet_reconstruct(particles::Vector{PseudoJet}; p::Real = -1, R = 
         tiledjet_set_jetinfo!(tiledjets[ijet], clusterseq, tiling, ijet, R2, p)
     end
 
-    # Now initalise all of the nearest neighbour tiles
+    # Now initialise all of the nearest neighbour tiles
     NNs, dij = set_nearest_neighbours!(clusterseq, tiling, tiledjets)
 
     # Main loop of the reconstruction

--- a/src/TiledAlgoLLStructs.jl
+++ b/src/TiledAlgoLLStructs.jl
@@ -1,7 +1,7 @@
 # Structures used internally by the tiled algorithm
 
 """Structure analogous to PseudoJet, but with the extra information
-needed for dealing with tiles for the tiled stragegy"""
+needed for dealing with tiles for the tiled strategy"""
 
 """
     struct TiledJet
@@ -193,7 +193,7 @@ end
 """
     Tiling(setup::TilingDef)
 
-Constructs a intial `Tiling` object based on the provided `setup` parameters.
+Constructs a initial `Tiling` object based on the provided `setup` parameters.
 
 # Arguments
 - `setup::TilingDef`: The setup parameters for the tiling.
@@ -289,7 +289,7 @@ end
     rightneighbours(center::Int, tiling::Tiling)
 
 Compute the indices of the right neighbors of a given center index in a tiling.
-This is used in the inital sweep to calculate the nearest neighbors, where the
+This is used in the initial sweep to calculate the nearest neighbors, where the
 search between jets for the nearest neighbour is bi-directional, thus when a
 tile is considered only the right neighbours are needed to compare jet
 distances as the left-hand tiles have been done from that tile already.

--- a/src/TiledAlgoUtils.jl
+++ b/src/TiledAlgoUtils.jl
@@ -3,7 +3,7 @@
 """
 	struct TilingDef
 
-A struct representing the definition of a spcific tiling scheme.
+A struct representing the definition of a specific tiling scheme.
 
 # Fields
 - `_tiles_eta_min::Float64`: The minimum rapidity of the tiles.
@@ -220,7 +220,7 @@ Compute the dij metric distance between two jets.
 The distance between the two jets.
 
 If `kt2_2` is equal to 0.0, then the first jet doesn't actually have a valid 
-neighbour, so it's treated as a single jet adjecent to the beam.
+neighbour, so it's treated as a single jet adjacent to the beam.
 """
 get_dij_dist(nn_dist, kt2_1, kt2_2, R2) = begin
     if kt2_2 == 0.0

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -13,7 +13,7 @@ Reads final state particles from a file and returns them as a vector of type T.
 - `maxevents=-1`: The maximum number of events to read. -1 means all events will
   be read.
 - `skipevents=0`: The number of events to skip before an event is included.
-- `T=PseudoJet`: The type of object to contruct and return.
+- `T=PseudoJet`: The type of object to construct and return.
 
 # Returns
 A vector of vectors of T objects, where each inner vector represents all
@@ -123,7 +123,7 @@ end
     fast_findmin(dij, n)
 
 Find the minimum value and its index in the first `n` elements of the `dij`
-array. The use of `@turbo` macro gives a significiant performance boost.
+array. The use of `@turbo` macro gives a significant performance boost.
 
 # Arguments
 - `dij`: An array of values.

--- a/test/bootstrap_examples.jl
+++ b/test/bootstrap_examples.jl
@@ -1,10 +1,10 @@
 # Bootstrap script to setup this local version of the JetReconstruction package
 # for running the examples
 
-println("Starting example boostrap script")
+println("Starting example bootstrap script")
 
 # if isfile(joinpath(@__DIR__, "..", "examples", "Manifest.toml"))
-#     println("Exisiting Manifest.toml found - assuming environment is already setup")
+#     println("Existing Manifest.toml found - assuming environment is already setup")
 #     exit(0)
 # end
 
@@ -25,8 +25,8 @@ println("Setting up examples project")
 using Pkg
 Pkg.instantiate()
 Pkg.resolve()
-println(("Seting JetReconstruction development package path: $local_pkg_path"))
+println(("Setting JetReconstruction development package path: $local_pkg_path"))
 Pkg.develop(path = local_pkg_path)
 Pkg.status()
 
-println("Finished examples boostrap script")
+println("Finished examples bootstrap script")

--- a/test/data/hepmc32summary.jl
+++ b/test/data/hepmc32summary.jl
@@ -18,7 +18,7 @@ Particle{T}() where {T} = Particle(LorentzVector{T}(0.0, 0.0, 0.0, 0.0), 0, 0, 0
 """ Read a [HepMC3](https://doi.org/10.1016/j.cpc.2020.107310) ascii file.
 
     Each event is passed to the provided function f as a vector of Particles. A
-    maximum number of events to read (value -1 to read all availble events) and
+    maximum number of events to read (value -1 to read all available events) and
     a number of events to skip at the beginning of the file can be provided.
 """
 function read_events(f, fin; maxevents = -1, skipevents = 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,7 @@ function main()
     include("test-pp-reconstruction.jl")
     include("test-ee-reconstruction.jl")
 
-    # Compare inputing data in PseudoJet with using a LorentzVector
+    # Compare inputting data in PseudoJet with using a LorentzVector
     do_test_compare_types(RecoStrategy.N2Plain, algname = pp_algorithms[-1], power = -1)
     do_test_compare_types(RecoStrategy.N2Tiled, algname = pp_algorithms[-1], power = -1)
 
@@ -105,7 +105,7 @@ function do_test_compare_to_fastjet(strategy::RecoStrategy.Strategy, fastjet_jet
         else
             selected_jets = inclusive_jets(cluster_seq; ptmin = ptmin)
         end
-        # And extact in out final_jets format
+        # And extract in out final_jets format
         finaljets = final_jets(selected_jets)
         sort_jets!(finaljets)
         push!(jet_collection, FinalJets(ievt, finaljets))
@@ -175,7 +175,7 @@ function do_test_compare_types(strategy::RecoStrategy.Strategy;
     end
 
     @testset "Jet Reconstruction Compare PseudoJet and LorentzVector, Strategy $strategy_name, Algorithm $algname" begin
-        # Here we test that inputing LorentzVector gave the same results as PseudoJets
+        # Here we test that inputting LorentzVector gave the same results as PseudoJets
         for (ievt, (event, event_lv)) in enumerate(zip(jet_collection, jet_collection_lv))
             @testset "Event $(ievt)" begin
                 @test size(event.jets) == size(event_lv.jets)

--- a/test/tests_examples.jl
+++ b/test/tests_examples.jl
@@ -5,7 +5,7 @@ using Test
 const example_dir = joinpath(pkgdir(JetReconstruction), "examples")
 const test_dir = joinpath(pkgdir(JetReconstruction), "test")
 
-# Need to ensure examples is properly instatiated
+# Need to ensure examples is properly instantiated
 run(`julia --project=$example_dir $test_dir/bootstrap_examples.jl`)
 
 # Now run a few tests with our examples


### PR DESCRIPTION
Fixing a few typos in the docstrings and comments from sources, tests and examples