### PR TITLE
Add jet parents retrieval

### DIFF
--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -638,7 +638,7 @@ function has_parents(p::FourMomentum,
 end
 
 """
-    parent_jets(jet::T, cs::ClusterSequence)::Tuple{Union{Nothing, T}, Union{Nothing, T}} where {T <: FourMomentum}
+    parent_jets(jet::T, cs::ClusterSequence{T})::Tuple{Union{Nothing, T}, Union{Nothing, T}} where {T <: FourMomentum}
 
 Find the parent jets of a given jet in a cluster sequence.
 
@@ -651,7 +651,7 @@ A tuple of two elements, each of which is either the parent jet object or
 `nothing` (if the jet has no parent).
 """
 function parent_jets(jet::T,
-                     cs::ClusterSequence)::Tuple{Union{Nothing, T},
+                     cs::ClusterSequence{T})::Tuple{Union{Nothing, T},
                                                  Union{Nothing, T}} where {T <:
                                                                            FourMomentum}
     hist_idx = jet._cluster_hist_index

--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -633,7 +633,7 @@ function has_parents(p::FourMomentum,
     p1 = history[N].parent1
     p2 = history[N].parent2
 
-    p1 == p2 == NonexistentParent ? result = false : result = true
+    result = !(p1 == p2 == NonexistentParent)
     return (result, p1, p2)
 end
 
@@ -652,8 +652,8 @@ A tuple of two elements, each of which is either the parent jet object or
 """
 function parent_jets(jet::T,
                      cs::ClusterSequence{T})::Tuple{Union{Nothing, T},
-                                                 Union{Nothing, T}} where {T <:
-                                                                           FourMomentum}
+                                                    Union{Nothing, T}} where {T <:
+                                                                              FourMomentum}
     hist_idx = jet._cluster_hist_index
     jet_history = cs.history[hist_idx]
 

--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -53,7 +53,8 @@ end
 """
     HistoryElement(jetp_index)
 
-Constructs a `HistoryElement` object with the given `jetp_index`, used for initialising the history with original particles.
+Constructs a `HistoryElement` object with the given `jetp_index`, used for
+initialising the history with original particles.
 
 # Arguments
 - `jetp_index`: The index of the jetp.

--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -612,32 +612,6 @@ function constituent_indexes(jet::T, cs::ClusterSequence{T}) where {T <: FourMom
 end
 
 """
-    has_parents(p::FourMomentum, clusterseq::ClusterSequence)::Tuple{boolean, Int64, Int64}
-
-Checks if the jet `p` is a child of two other jets, after clustering 
-
-# Arguments
-- `p`: The jet to check.
-- `clusterseq`: The cluster sequence object.
-
-# Returns
-`Tuple{Bool, Int64, Int64}`: First element is true or false depending if the jet
- has a parent or not. If the jet has parents, returns the *indices* of the
- parent jets in the *history element* as elements 2 and 3. Otherwise, returns
- JetReconstruction.NonexistentParent
-"""
-function has_parents(p::FourMomentum,
-                     clusterseq::ClusterSequence)::Tuple{Bool, Int64, Int64}
-    history = clusterseq.history
-    N = p._cluster_hist_index
-    p1 = history[N].parent1
-    p2 = history[N].parent2
-
-    result = !(p1 == p2 == NonexistentParent)
-    return (result, p1, p2)
-end
-
-"""
     parent_jets(jet::T, cs::ClusterSequence{T})::Tuple{Union{Nothing, T}, Union{Nothing, T}} where {T <: FourMomentum}
 
 Find the parent jets of a given jet in a cluster sequence.

--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -610,3 +610,57 @@ An vector of indices representing the original constituents of the given jet.
 function constituent_indexes(jet::T, cs::ClusterSequence{T}) where {T <: FourMomentum}
     get_all_ancestors(cs.history[jet._cluster_hist_index].jetp_index, cs)
 end
+
+"""
+    has_parents(p::FourMomentum, clusterseq::ClusterSequence)::Tuple{boolean, Int64, Int64}
+
+Checks if the jet `p` is a child of two other jets, after clustering 
+
+# Arguments
+- `p`: The jet to check.
+- `clusterseq`: The cluster sequence object.
+
+# Returns
+`Tuple{Bool, Int64, Int64}`: First element is true or false depending if the jet
+ has a parent or not. If the jet has parents, returns the *indices* of the
+ parent jets in the *history element* as elements 2 and 3. Otherwise, returns
+ JetReconstruction.NonexistentParent
+"""
+function has_parents(p::FourMomentum,
+                     clusterseq::ClusterSequence)::Tuple{Bool, Int64, Int64}
+    history = clusterseq.history
+    N = p._cluster_hist_index
+    p1 = history[N].parent1
+    p2 = history[N].parent2
+
+    p1 == p2 == NonexistentParent ? result = false : result = true
+    return (result, p1, p2)
+end
+
+"""
+    parent_jets(jet::T, cs::ClusterSequence)::Tuple{Union{Nothing, T}, Union{Nothing, T}} where {T <: FourMomentum}
+
+Find the parent jets of a given jet in a cluster sequence.
+
+# Arguments
+- `jet::T`: The jet for which to find the parent jets.
+- `cs::ClusterSequence`: The cluster sequence object.
+
+# Returns
+A tuple of two elements, each of which is either the parent jet object or
+`nothing` (if the jet has no parent).
+"""
+function parent_jets(jet::T,
+                     cs::ClusterSequence)::Tuple{Union{Nothing, T},
+                                                 Union{Nothing, T}} where {T <:
+                                                                           FourMomentum}
+    hist_idx = jet._cluster_hist_index
+    jet_history = cs.history[hist_idx]
+
+    parent1_idx, parent2_idx = jet_history.parent1, jet_history.parent2
+
+    parent1_jet = parent1_idx > 0 ? cs.jets[cs.history[parent1_idx].jetp_index] : nothing
+    parent2_jet = parent2_idx > 0 ? cs.jets[cs.history[parent2_idx].jetp_index] : nothing
+
+    return parent1_jet, parent2_jet
+end

--- a/src/JetReconstruction.jl
+++ b/src/JetReconstruction.jl
@@ -48,7 +48,7 @@ export RecoStrategy, JetAlgorithm
 # ClusterSequence type
 include("ClusterSequence.jl")
 export ClusterSequence, inclusive_jets, exclusive_jets, n_exclusive_jets, constituents,
-       constituent_indexes
+       constituent_indexes, parent_jets
 
 ## N2Plain algorithm
 # Algorithmic part for simple sequential implementation

--- a/src/Substructure.jl
+++ b/src/Substructure.jl
@@ -1,26 +1,4 @@
 """
-    has_parents(p, clusterseq) -> (boolean, Int64, Int64)
-
-Checks if the jet `p` is a child of two other jets, after clustering 
-
-# Arguments
-- `p::PseudoJet`: The jet to check.
-- `clusterseq::ClusterSequence`: The cluster sequence object.
-
-# Returns
-- `(boolean, Int64, Int64)`: true or false depending on if the jet has a parent or not. If the jet has a parent, returns the indices of the parent jets in the history element. Otherwise, returns -2 (NonexistentParent).
-"""
-function has_parents(p::PseudoJet, clusterseq::ClusterSequence)
-    history = clusterseq.history
-    N = p._cluster_hist_index
-    p1 = history[N].parent1
-    p2 = history[N].parent2
-
-    p1 == p2 == NonexistentParent ? result = false : result = true
-    return (result, p1, p2)
-end
-
-"""
     deltaR(jet1, jet2) -> Float64
 
 Function to calculate the distance in the y-ϕ plane between two jets `jet1` and `jet2`

--- a/src/Substructure.jl
+++ b/src/Substructure.jl
@@ -127,7 +127,7 @@ function mass_drop(jet::PseudoJet, clusterseq::ClusterSequence, tag::MassDropTag
     while true
         parent1, parent2 = parent_jets(jet, clusterseq)
 
-        if !isnothing(parent1)
+        if !isnothing(parent1) && !(isnothing(parent2))
             if m2(parent1) < m2(parent2)
                 parent1, parent2 = parent2, parent1
             end
@@ -174,7 +174,7 @@ function soft_drop(jet::PseudoJet, clusterseq::ClusterSequence,
     while true
         parent1, parent2 = parent_jets(new_jet, new_clusterseq)
 
-        if !isnothing(parent1)
+        if !isnothing(parent1) && !(isnothing(parent2))
             if m2(parent1) < m2(parent2)
                 parent1, parent2 = parent2, parent1
             end

--- a/src/Substructure.jl
+++ b/src/Substructure.jl
@@ -125,14 +125,10 @@ function mass_drop(jet::PseudoJet, clusterseq::ClusterSequence, tag::MassDropTag
     hist = clusterseq.history
 
     while true
-        had_parents, p1, p2 = has_parents(jet, clusterseq)
+        parent1, parent2 = parent_jets(jet, clusterseq)
 
-        if had_parents
-            parent1 = all_jets[hist[p1].jetp_index]
-            parent2 = all_jets[hist[p2].jetp_index]
-
+        if !isnothing(parent1)
             if m2(parent1) < m2(parent2)
-                p1, p2 = p2, p1
                 parent1, parent2 = parent2, parent1
             end
 
@@ -176,21 +172,17 @@ function soft_drop(jet::PseudoJet, clusterseq::ClusterSequence,
     hist = new_clusterseq.history
 
     while true
-        had_parents, p1, p2 = has_parents(new_jet, new_clusterseq)
+        parent1, parent2 = parent_jets(new_jet, new_clusterseq)
 
-        if had_parents
-            parent1 = all_jets[hist[p1].jetp_index]
-            parent2 = all_jets[hist[p2].jetp_index]
-
+        if !isnothing(parent1)
             if m2(parent1) < m2(parent2)
-                p1, p2 = p2, p1
                 parent1, parent2 = parent2, parent1
             end
 
-            pti = pt(parent1)
-            ptj = pt(parent2)
+            pt1 = pt(parent1)
+            pt2 = pt(parent2)
 
-            if min(pti, ptj) / (pti + ptj) >
+            if min(pt1, pt2) / (pt1 + pt2) >
                tag.zcut * (deltaR(parent1, parent2) / rad)^tag.b
                 return new_jet
             else

--- a/test/test-constituents.jl
+++ b/test/test-constituents.jl
@@ -53,17 +53,4 @@ end
         no_parents = JetReconstruction.parent_jets(cluster_seq.jets[1], cluster_seq)
         @test isnothing(no_parents[1]) && isnothing(no_parents[2])
     end
-
-    @testset "Parent indexes for jet number $(event_no)" begin
-        my_parent_indexes = JetReconstruction.has_parents(pj_jets[event_no], cluster_seq)
-        @test my_parent_indexes[1] == true
-        @test my_parent_indexes[2] == expected_parent_indexes[1]
-        @test my_parent_indexes[3] == expected_parent_indexes[2]
-    end
-    @testset "Parent indexes of input cluster" begin
-        no_parent_indexes = JetReconstruction.has_parents(cluster_seq.jets[1], cluster_seq)
-        @test no_parent_indexes[1] == false
-        @test (no_parent_indexes[2] == JetReconstruction.NonexistentParent) &&
-              (no_parent_indexes[3] == JetReconstruction.NonexistentParent)
-    end
 end


### PR DESCRIPTION
Add `parent_jets()` accessor, that returns a jet's parents or nothing. Export this method.

~~"Promote" `has_parents` to ClusterSequence source file and ensure it works with both jet types (or any `FourMomentum`).~~ *Remove `has_parents` as unneeded*

Add tests for parent jet retrieval, in case where a jet has parents and also when it doesn't.

Closes #100 