### PR TITLE
Fix default p value and refactor tests

### DIFF
--- a/examples/test.sh
+++ b/examples/test.sh
@@ -6,6 +6,12 @@ julia --project instrumented-jetreco.jl --algorithm=AntiKt -R 0.4 ../test/data/e
 echo "pp 14 TeV Plain profile"
 julia --project instrumented-jetreco.jl --algorithm=AntiKt -R 0.4 ../test/data/events.pp13TeV.hepmc3.gz -S N2Plain -m 2 --profile test
 
+echo "pp 14TeV CA"
+julia --project instrumented-jetreco.jl --algorithm=CA -R 1.0 ../test/data/events.pp13TeV.hepmc3.gz
+
+echo "pp 14TeV Kt"
+julia --project instrumented-jetreco.jl --algorithm=Kt -R 1.0 ../test/data/events.pp13TeV.hepmc3.gz
+
 echo "ee H Durham allocation test"
 julia --project instrumented-jetreco.jl --algorithm=Durham --alloc ../test/data/events.eeH.hepmc3.gz
 

--- a/src/GenericAlgo.jl
+++ b/src/GenericAlgo.jl
@@ -52,7 +52,7 @@ jet_reconstruct(particles; algorithm = JetAlgorithm.Durham)
 jet_reconstruct(particles; algorithm = JetAlgorithm.GenKt, p = 0.5, R = 1.0)
 ```
 """
-function jet_reconstruct(particles; p::Union{Real, Nothing} = -1, R = 1.0,
+function jet_reconstruct(particles; p::Union{Real, Nothing} = nothing, R = 1.0,
                          algorithm::Union{JetAlgorithm.Algorithm, Nothing} = nothing,
                          recombine = +,
                          strategy = RecoStrategy.Best)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ function main()
     include("test-algpower-consistency.jl")
 
     # jet_reconstruct() interface check
-    include("test-jet_reconstruct-if.jl")
+    include("test-jet_reconstruct-interface.jl")
 
     # New test structure, factorised tests for pp and e+e-
     include("test-pp-reconstruction.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ function main()
     include("test-algpower-consistency.jl")
 
     # jet_reconstruct() interface check
-    include("test-jet-reco-if.jl")
+    include("test-jet_reconstruct-if.jl")
 
     # New test structure, factorised tests for pp and e+e-
     include("test-pp-reconstruction.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,8 +17,7 @@ function main()
     include("test-selection.jl")
 
     # Compare inputting data in PseudoJet with using a LorentzVector
-    do_test_compare_types(RecoStrategy.N2Plain, algname = pp_algorithms[-1], power = -1)
-    do_test_compare_types(RecoStrategy.N2Tiled, algname = pp_algorithms[-1], power = -1)
+    include("test-compare-types.jl")
 
     # Check jet constituents
     include("test-constituents.jl")
@@ -34,61 +33,6 @@ function main()
 
     # Test with Aqua (https://juliatesting.github.io/Aqua.jl/stable/)
     include("test-aqua.jl")
-end
-
-function do_test_compare_types(strategy::RecoStrategy.Strategy;
-                               algname = "Unknown",
-                               ptmin::Float64 = 5.0,
-                               distance::Float64 = 0.4,
-                               power::Integer = -1)
-
-    # Strategy
-    if (strategy == RecoStrategy.N2Plain)
-        jet_reconstruction = plain_jet_reconstruct
-        strategy_name = "N2Plain"
-    elseif (strategy == RecoStrategy.N2Tiled)
-        jet_reconstruction = tiled_jet_reconstruct
-        strategy_name = "N2Tiled"
-    else
-        throw(ErrorException("Strategy not yet implemented"))
-    end
-
-    # Now run our jet reconstruction...
-    # From PseudoJets
-    events::Vector{Vector{PseudoJet}} = read_final_state_particles(events_file_pp)
-    jet_collection = FinalJets[]
-    for (ievt, event) in enumerate(events)
-        finaljets = final_jets(inclusive_jets(jet_reconstruction(event, R = distance,
-                                                                 p = power), ptmin = ptmin))
-        sort_jets!(finaljets)
-        push!(jet_collection, FinalJets(ievt, finaljets))
-    end
-
-    # From LorentzVector
-    events_lv::Vector{Vector{LorentzVector}} = read_final_state_particles(events_file_pp;
-                                                                          T = LorentzVector)
-    jet_collection_lv = FinalJets[]
-    for (ievt, event) in enumerate(events_lv)
-        finaljets = final_jets(inclusive_jets(jet_reconstruction(event, R = distance,
-                                                                 p = power), ptmin = ptmin))
-        sort_jets!(finaljets)
-        push!(jet_collection_lv, FinalJets(ievt, finaljets))
-    end
-
-    @testset "Jet Reconstruction Compare PseudoJet and LorentzVector, Strategy $strategy_name, Algorithm $algname" begin
-        # Here we test that inputting LorentzVector gave the same results as PseudoJets
-        for (ievt, (event, event_lv)) in enumerate(zip(jet_collection, jet_collection_lv))
-            @testset "Event $(ievt)" begin
-                @test size(event.jets) == size(event_lv.jets)
-                # Test each jet in turn
-                for (jet, jet_lv) in zip(event.jets, event_lv.jets)
-                    @test jet.rap≈jet_lv.rap atol=1e-7
-                    @test jet.phi≈jet_lv.phi atol=1e-7
-                    @test jet.pt≈jet_lv.pt rtol=1e-6
-                end
-            end
-        end
-    end
 end
 
 logger = ConsoleLogger(stdout, Logging.Warn)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,33 +3,11 @@
 include("common.jl")
 
 function main()
-    # A few unit tests
-    @testset "Algorithm/power consistency" begin
-        @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.AntiKt,
-                                                                  p = -1)
-        @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.CA,
-                                                                  p = 0)
-        @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.Kt,
-                                                                  p = 1)
+    # Algorithm/power consistency checks
+    include("test-algpower-consistency.jl")
 
-        @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.AntiKt,
-                                                                  p = nothing)
-        @test JetReconstruction.check_algorithm_power_consistency(algorithm = nothing,
-                                                                  p = -1)
-
-        @test_throws ArgumentError JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.AntiKt,
-                                                                                       p = 0)
-        @test_throws ArgumentError JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.Kt,
-                                                                                       p = 1.5)
-
-        @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.GenKt,
-                                                                  p = 1.5)
-        @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.GenKt,
-                                                                  p = -0.5)
-
-        @test_throws ArgumentError JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.GenKt,
-                                                                                       p = nothing)
-    end
+    # jet_reconstruct() interface check
+    include("test-jet-reco-if.jl")
 
     # New test structure, factorised tests for pp and e+e-
     include("test-pp-reconstruction.jl")

--- a/test/test-algpower-consistency.jl
+++ b/test/test-algpower-consistency.jl
@@ -1,0 +1,30 @@
+# Tests of algorithm/power consistency checks
+
+include("common.jl")
+
+@testset "Algorithm/power consistency" begin
+    @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.AntiKt,
+                                                              p = -1)
+    @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.CA,
+                                                              p = 0)
+    @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.Kt,
+                                                              p = 1)
+
+    @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.AntiKt,
+                                                              p = nothing)
+    @test JetReconstruction.check_algorithm_power_consistency(algorithm = nothing,
+                                                              p = -1)
+
+    @test_throws ArgumentError JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.AntiKt,
+                                                                                   p = 0)
+    @test_throws ArgumentError JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.Kt,
+                                                                                   p = 1.5)
+
+    @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.GenKt,
+                                                              p = 1.5)
+    @test JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.GenKt,
+                                                              p = -0.5)
+
+    @test_throws ArgumentError JetReconstruction.check_algorithm_power_consistency(algorithm = JetAlgorithm.GenKt,
+                                                                                   p = nothing)
+end

--- a/test/test-compare-types.jl
+++ b/test/test-compare-types.jl
@@ -3,11 +3,11 @@
 include("common.jl")
 
 function do_test_compare_types(strategy::RecoStrategy.Strategy;
-    algname = "Unknown",
-    ptmin::Float64 = 5.0,
-    distance::Float64 = 0.4,
-    power::Integer = -1)
-    
+                               algname = "Unknown",
+                               ptmin::Float64 = 5.0,
+                               distance::Float64 = 0.4,
+                               power::Integer = -1)
+
     # Strategy
     if (strategy == RecoStrategy.N2Plain)
         jet_reconstruction = plain_jet_reconstruct
@@ -18,29 +18,29 @@ function do_test_compare_types(strategy::RecoStrategy.Strategy;
     else
         throw(ErrorException("Strategy not yet implemented"))
     end
-    
+
     # Now run our jet reconstruction...
     # From PseudoJets
     events::Vector{Vector{PseudoJet}} = read_final_state_particles(events_file_pp)
     jet_collection = FinalJets[]
     for (ievt, event) in enumerate(events)
         finaljets = final_jets(inclusive_jets(jet_reconstruction(event, R = distance,
-        p = power), ptmin = ptmin))
+                                                                 p = power), ptmin = ptmin))
         sort_jets!(finaljets)
         push!(jet_collection, FinalJets(ievt, finaljets))
     end
-    
+
     # From LorentzVector
     events_lv::Vector{Vector{LorentzVector}} = read_final_state_particles(events_file_pp;
-    T = LorentzVector)
+                                                                          T = LorentzVector)
     jet_collection_lv = FinalJets[]
     for (ievt, event) in enumerate(events_lv)
         finaljets = final_jets(inclusive_jets(jet_reconstruction(event, R = distance,
-        p = power), ptmin = ptmin))
+                                                                 p = power), ptmin = ptmin))
         sort_jets!(finaljets)
         push!(jet_collection_lv, FinalJets(ievt, finaljets))
     end
-    
+
     @testset "Jet Reconstruction Compare PseudoJet and LorentzVector, Strategy $strategy_name, Algorithm $algname" begin
         # Here we test that inputting LorentzVector gave the same results as PseudoJets
         for (ievt, (event, event_lv)) in enumerate(zip(jet_collection, jet_collection_lv))
@@ -59,4 +59,3 @@ end
 
 do_test_compare_types(RecoStrategy.N2Plain, algname = pp_algorithms[-1], power = -1)
 do_test_compare_types(RecoStrategy.N2Tiled, algname = pp_algorithms[-1], power = -1)
-

--- a/test/test-compare-types.jl
+++ b/test/test-compare-types.jl
@@ -1,0 +1,62 @@
+# Compare inputting data in PseudoJet with using a LorentzVector
+
+include("common.jl")
+
+function do_test_compare_types(strategy::RecoStrategy.Strategy;
+    algname = "Unknown",
+    ptmin::Float64 = 5.0,
+    distance::Float64 = 0.4,
+    power::Integer = -1)
+    
+    # Strategy
+    if (strategy == RecoStrategy.N2Plain)
+        jet_reconstruction = plain_jet_reconstruct
+        strategy_name = "N2Plain"
+    elseif (strategy == RecoStrategy.N2Tiled)
+        jet_reconstruction = tiled_jet_reconstruct
+        strategy_name = "N2Tiled"
+    else
+        throw(ErrorException("Strategy not yet implemented"))
+    end
+    
+    # Now run our jet reconstruction...
+    # From PseudoJets
+    events::Vector{Vector{PseudoJet}} = read_final_state_particles(events_file_pp)
+    jet_collection = FinalJets[]
+    for (ievt, event) in enumerate(events)
+        finaljets = final_jets(inclusive_jets(jet_reconstruction(event, R = distance,
+        p = power), ptmin = ptmin))
+        sort_jets!(finaljets)
+        push!(jet_collection, FinalJets(ievt, finaljets))
+    end
+    
+    # From LorentzVector
+    events_lv::Vector{Vector{LorentzVector}} = read_final_state_particles(events_file_pp;
+    T = LorentzVector)
+    jet_collection_lv = FinalJets[]
+    for (ievt, event) in enumerate(events_lv)
+        finaljets = final_jets(inclusive_jets(jet_reconstruction(event, R = distance,
+        p = power), ptmin = ptmin))
+        sort_jets!(finaljets)
+        push!(jet_collection_lv, FinalJets(ievt, finaljets))
+    end
+    
+    @testset "Jet Reconstruction Compare PseudoJet and LorentzVector, Strategy $strategy_name, Algorithm $algname" begin
+        # Here we test that inputting LorentzVector gave the same results as PseudoJets
+        for (ievt, (event, event_lv)) in enumerate(zip(jet_collection, jet_collection_lv))
+            @testset "Event $(ievt)" begin
+                @test size(event.jets) == size(event_lv.jets)
+                # Test each jet in turn
+                for (jet, jet_lv) in zip(event.jets, event_lv.jets)
+                    @test jet.rap≈jet_lv.rap atol=1e-7
+                    @test jet.phi≈jet_lv.phi atol=1e-7
+                    @test jet.pt≈jet_lv.pt rtol=1e-6
+                end
+            end
+        end
+    end
+end
+
+do_test_compare_types(RecoStrategy.N2Plain, algname = pp_algorithms[-1], power = -1)
+do_test_compare_types(RecoStrategy.N2Tiled, algname = pp_algorithms[-1], power = -1)
+

--- a/test/test-jet_reconstruct-if.jl
+++ b/test/test-jet_reconstruct-if.jl
@@ -5,25 +5,43 @@ include("common.jl")
 let inputs = JetReconstruction.read_final_state_particles(events_file_ee)
     @testset "jet_reconstruct() interface" begin
         # EE Algorithms
-        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Durham)) == ClusterSequence{EEjet}
-        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.EEKt, p=-1, R=1.0)) == ClusterSequence{EEjet}
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.EEKt)) == ClusterSequence{EEjet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Durham)) ==
+              ClusterSequence{EEjet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.EEKt, p = -1,
+                                     R = 1.0)) == ClusterSequence{EEjet}
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1];
+                                                          algorithm = JetAlgorithm.EEKt))==ClusterSequence{EEjet}
 
         # PP Algorithms
-        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.AntiKt)) == ClusterSequence{PseudoJet}
-        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.CA)) == ClusterSequence{PseudoJet}
-        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Kt)) == ClusterSequence{PseudoJet}
-        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.AntiKt, p=-1)) == ClusterSequence{PseudoJet}
-        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.CA, p=0)) == ClusterSequence{PseudoJet}
-        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Kt, p=1)) == ClusterSequence{PseudoJet}
-        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.GenKt, p=1.0, R=0.4)) == ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.AntiKt)) ==
+              ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.CA)) ==
+              ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Kt)) ==
+              ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.AntiKt, p = -1)) ==
+              ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.CA, p = 0)) ==
+              ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Kt, p = 1)) ==
+              ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.GenKt, p = 1.0,
+                                     R = 0.4)) == ClusterSequence{PseudoJet}
 
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.AntiKt, p=0)) == ClusterSequence{PseudoJet}
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.CA, p=1)) == ClusterSequence{PseudoJet}
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Kt, p=-1)) == ClusterSequence{PseudoJet}
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.GenKt, R=0.4)) == ClusterSequence{PseudoJet}
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1];
+                                                          algorithm = JetAlgorithm.AntiKt,
+                                                          p = 0))==ClusterSequence{PseudoJet}
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1];
+                                                          algorithm = JetAlgorithm.CA,
+                                                          p = 1))==ClusterSequence{PseudoJet}
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1];
+                                                          algorithm = JetAlgorithm.Kt,
+                                                          p = -1))==ClusterSequence{PseudoJet}
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1];
+                                                          algorithm = JetAlgorithm.GenKt,
+                                                          R = 0.4))==ClusterSequence{PseudoJet}
 
         # No algorithm or power will throw
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1])) == ClusterSequence{PseudoJet}
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]))==ClusterSequence{PseudoJet}
     end
 end

--- a/test/test-jet_reconstruct-if.jl
+++ b/test/test-jet_reconstruct-if.jl
@@ -22,5 +22,8 @@ let inputs = JetReconstruction.read_final_state_particles(events_file_ee)
         @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.CA, p=1)) == ClusterSequence{PseudoJet}
         @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Kt, p=-1)) == ClusterSequence{PseudoJet}
         @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.GenKt, R=0.4)) == ClusterSequence{PseudoJet}
+
+        # No algorithm or power will throw
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1])) == ClusterSequence{PseudoJet}
     end
 end

--- a/test/test-jet_reconstruct-if.jl
+++ b/test/test-jet_reconstruct-if.jl
@@ -1,0 +1,26 @@
+# Test the different interface modes of the main jet_reconstruct() function
+
+include("common.jl")
+
+let inputs = JetReconstruction.read_final_state_particles(events_file_ee)
+    @testset "jet_reconstruct() interface" begin
+        # EE Algorithms
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Durham)) == ClusterSequence{EEjet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.EEKt, p=-1, R=1.0)) == ClusterSequence{EEjet}
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.EEKt)) == ClusterSequence{EEjet}
+
+        # PP Algorithms
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.AntiKt)) == ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.CA)) == ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Kt)) == ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.AntiKt, p=-1)) == ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.CA, p=0)) == ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Kt, p=1)) == ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.GenKt, p=1.0, R=0.4)) == ClusterSequence{PseudoJet}
+
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.AntiKt, p=0)) == ClusterSequence{PseudoJet}
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.CA, p=1)) == ClusterSequence{PseudoJet}
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.Kt, p=-1)) == ClusterSequence{PseudoJet}
+        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.GenKt, R=0.4)) == ClusterSequence{PseudoJet}
+    end
+end

--- a/test/test-jet_reconstruct-interface.jl
+++ b/test/test-jet_reconstruct-interface.jl
@@ -9,8 +9,8 @@ let inputs = JetReconstruction.read_final_state_particles(events_file_ee)
               ClusterSequence{EEjet}
         @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.EEKt, p = -1,
                                      R = 1.0)) == ClusterSequence{EEjet}
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1];
-                                                          algorithm = JetAlgorithm.EEKt))==ClusterSequence{EEjet}
+        @test_throws ArgumentError jet_reconstruct(inputs[1];
+                                                   algorithm = JetAlgorithm.EEKt)
 
         # PP Algorithms
         @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.AntiKt)) ==
@@ -28,20 +28,27 @@ let inputs = JetReconstruction.read_final_state_particles(events_file_ee)
         @test typeof(jet_reconstruct(inputs[1]; algorithm = JetAlgorithm.GenKt, p = 1.0,
                                      R = 0.4)) == ClusterSequence{PseudoJet}
 
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1];
-                                                          algorithm = JetAlgorithm.AntiKt,
-                                                          p = 0))==ClusterSequence{PseudoJet}
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1];
-                                                          algorithm = JetAlgorithm.CA,
-                                                          p = 1))==ClusterSequence{PseudoJet}
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1];
-                                                          algorithm = JetAlgorithm.Kt,
-                                                          p = -1))==ClusterSequence{PseudoJet}
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1];
-                                                          algorithm = JetAlgorithm.GenKt,
-                                                          R = 0.4))==ClusterSequence{PseudoJet}
+        @test_throws ArgumentError jet_reconstruct(inputs[1];
+                                                   algorithm = JetAlgorithm.AntiKt,
+                                                   p = 0)
+        @test_throws ArgumentError jet_reconstruct(inputs[1];
+                                                   algorithm = JetAlgorithm.CA,
+                                                   p = 1)
+        @test_throws ArgumentError jet_reconstruct(inputs[1];
+                                                   algorithm = JetAlgorithm.Kt,
+                                                   p = -1)
+        @test_throws ArgumentError jet_reconstruct(inputs[1];
+                                                   algorithm = JetAlgorithm.GenKt,
+                                                   R = 0.4)
+
+        # Supported for now, but will deprecate this calling mode, where only
+        # the power is given, at the next major release
+        @test typeof(jet_reconstruct(inputs[1]; p = -1)) == ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; p = 0)) == ClusterSequence{PseudoJet}
+        @test typeof(jet_reconstruct(inputs[1]; p = 1)) == ClusterSequence{PseudoJet}
+        @test_throws KeyError jet_reconstruct(inputs[1]; p = 0.5)
 
         # No algorithm or power will throw
-        @test_throws ArgumentError typeof(jet_reconstruct(inputs[1]))==ClusterSequence{PseudoJet}
+        @test_throws ArgumentError jet_reconstruct(inputs[1])
     end
 end


### PR DESCRIPTION
Fix the default value for `p` in `jet_reconstruct()` to be `nothing` (see #126).

Refactor the last tests run inside `runtests.jl` to be independent subtests.

Add a couple more example test cases 

Fixes #126 
Fixes #127 