### PR TITLE
add mutable keyword in mutable struct docstrings

### DIFF
--- a/src/EEjet.jl
+++ b/src/EEjet.jl
@@ -1,5 +1,5 @@
 """
-    struct EEjet
+    mutable struct EEjet
 
 The `EEjet` struct is a 4-momentum object used for the e+e jet reconstruction routines.
 

--- a/src/TiledAlgoLLStructs.jl
+++ b/src/TiledAlgoLLStructs.jl
@@ -4,7 +4,7 @@
 needed for dealing with tiles for the tiled strategy"""
 
 """
-    struct TiledJet
+   mutable struct TiledJet
 
 TiledJet represents a jet in a tiled algorithm for jet reconstruction, with
 additional information to track the jet's position in the tiled structures.


### PR DESCRIPTION
This is very small. The docstring for `PseudoJet` includes `mutable` but docstings for other `mutable struct`s don't. I'm not sure whether including `mutable` is a recommended practice - I think I've seen packages both putting and avoiding it in the docs