### PR TITLE
By default use local version of JetReconstruction in examples and docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,6 +6,9 @@ JetReconstruction = "44e8cb2c-dfab-4825-9c70-d4808a591196"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
+[sources]
+JetReconstruction = {path = ".."}
+
 [compat]
 Documenter = "1.4"
 EDM4hep = "0.4"

--- a/examples/EDM4hep/Project.toml
+++ b/examples/EDM4hep/Project.toml
@@ -3,3 +3,6 @@ ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 EDM4hep = "eb32b910-dde9-4347-8fce-cd6be3498f0c"
 JetReconstruction = "44e8cb2c-dfab-4825-9c70-d4808a591196"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[sources]
+JetReconstruction = {path = "../.."}

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -8,3 +8,6 @@ LorentzVectorHEP = "f612022c-142a-473f-8cfd-a09cf3793c6c"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 ProfileSVG = "132c30aa-f267-4189-9183-c8a63c7e05e6"
 StatProfilerHTML = "a8a75453-ed82-57c9-9e16-4cd1196ecbf5"
+
+[sources]
+JetReconstruction = {path = ".."}

--- a/examples/constituents/Project.toml
+++ b/examples/constituents/Project.toml
@@ -2,3 +2,6 @@
 JetReconstruction = "44e8cb2c-dfab-4825-9c70-d4808a591196"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LorentzVectorHEP = "f612022c-142a-473f-8cfd-a09cf3793c6c"
+
+[sources]
+JetReconstruction = {path = "../.."}

--- a/examples/substructure/Project.toml
+++ b/examples/substructure/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 JetReconstruction = "44e8cb2c-dfab-4825-9c70-d4808a591196"
+
+[sources]
+JetReconstruction = {path = "../.."}

--- a/examples/visualisation/Project.toml
+++ b/examples/visualisation/Project.toml
@@ -7,3 +7,6 @@ JetReconstruction = "44e8cb2c-dfab-4825-9c70-d4808a591196"
 LorentzVectorHEP = "f612022c-142a-473f-8cfd-a09cf3793c6c"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
+
+[sources]
+JetReconstruction = {path = "../.."}


### PR DESCRIPTION
One too many times I forgot to `dev` the main package and was running with package from JuliaHub and wondering where are my changes

I propose to use [`[sources]`](https://pkgdocs.julialang.org/v1.11/toml-files/#The-[sources]-section) directive so examples docs automatically pick-up local version of JetReconstruction.jl. It's still possible to `free` or `dev` somewhere else later.  This also shouldn't  interfere with CI.

The `[sources]` directive was added in Julia 1.11. For earlier versions this is transparent and not doing anything, so the package should still be `dev`ed manually. 


Probably in 1.12 some of these could be replaced with [`[workspace]`](https://pkgdocs.julialang.org/dev/toml-files/#The-[workspace]-section) to resolve all the dependencies for sub-projects together. 