### PR TITLE
fix dump in jetreco and instrumented-jetreco examples

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -6,3 +6,5 @@
 profile/*
 # Playground for development scripts and notebooks
 playground/*
+# Ignore outputs from tests
+test-output*

--- a/examples/instrumented-jetreco.jl
+++ b/examples/instrumented-jetreco.jl
@@ -176,7 +176,7 @@ function benchmark_jet_reco(events::Vector{Vector{T}};
                     "$(jet_output)"
                 end
                 if !isnothing(dump)
-                    push!(jet_collection, FinalJets(ievt, finaljets))
+                    push!(jet_collection, FinalJets(ievt, final_jets(finaljets)))
                 end
                 if dump_cs
                     println("Cluster sequence for event $(ievt)")

--- a/examples/instrumented-jetreco.jl
+++ b/examples/instrumented-jetreco.jl
@@ -159,24 +159,24 @@ function benchmark_jet_reco(events::Vector{Vector{T}};
             cs = jet_reconstruct(event; R = distance, p = p, algorithm = algorithm,
                                  strategy = strategy, recombine...)
             if !isnothing(njets)
-                finaljets = exclusive_jets(cs; njets = njets)
+                selectedjets = exclusive_jets(cs; njets = njets)
             elseif !isnothing(dcut)
-                finaljets = exclusive_jets(cs; dcut = dcut)
+                selectedjets = exclusive_jets(cs; dcut = dcut)
             else
-                finaljets = inclusive_jets(cs; ptmin = ptmin)
+                selectedjets = inclusive_jets(cs; ptmin = ptmin)
             end
             # Only print the jet content once
             if irun == 0 || nsamples == 1
                 @info begin
                     jet_output = "Event $(ievt)\n"
-                    sort!(finaljets, by = x -> pt(x), rev = true)
-                    for (ijet, jet) in enumerate(finaljets)
+                    sort!(selectedjets, by = x -> pt(x), rev = true)
+                    for (ijet, jet) in enumerate(selectedjets)
                         jet_output *= " $(ijet) - $(jet)\n"
                     end
                     "$(jet_output)"
                 end
                 if !isnothing(dump)
-                    push!(jet_collection, FinalJets(ievt, final_jets(finaljets)))
+                    push!(jet_collection, FinalJets(ievt, final_jets(selectedjets)))
                 end
                 if dump_cs
                     println("Cluster sequence for event $(ievt)")

--- a/examples/jetreco.jl
+++ b/examples/jetreco.jl
@@ -34,6 +34,11 @@ function jet_process(events::Vector{Vector{T}};
                      dump::Union{String, Nothing} = nothing) where {T <:
                                                                     JetReconstruction.FourMomentum}
 
+    # If we are dumping the results, setup the JSON structure
+    if !isnothing(dump)
+        jet_collection = FinalJets[]
+    end
+
     # Set consistent algorithm power
     p = JetReconstruction.get_algorithm_power(p = p, algorithm = algorithm)
     @info "Jet reconstruction will use $(algorithm) with power $(p)"
@@ -69,7 +74,7 @@ function jet_process(events::Vector{Vector{T}};
             "$(jet_output)"
         end
         if !isnothing(dump)
-            push!(jet_collection, FinalJets(ievt, finaljets))
+            push!(jet_collection, FinalJets(ievt, final_jets(finaljets)))
         end
     end
 

--- a/examples/jetreco.jl
+++ b/examples/jetreco.jl
@@ -59,22 +59,22 @@ function jet_process(events::Vector{Vector{T}};
                                       strategy = strategy)
         # Now select jets, with inclusive or exclusive parameters
         if !isnothing(njets)
-            finaljets = exclusive_jets(cluster_seq; njets = njets)
+            selectedjets = exclusive_jets(cluster_seq; njets = njets)
         elseif !isnothing(dcut)
-            finaljets = exclusive_jets(cluster_seq; dcut = dcut)
+            selectedjets = exclusive_jets(cluster_seq; dcut = dcut)
         else
-            finaljets = inclusive_jets(cluster_seq; ptmin = ptmin)
+            selectedjets = inclusive_jets(cluster_seq; ptmin = ptmin)
         end
         @info begin
             jet_output = "Event $(ievt)\n"
-            sort!(finaljets, by = x -> pt(x), rev = true)
-            for (ijet, jet) in enumerate(finaljets)
+            sort!(selectedjets, by = x -> pt(x), rev = true)
+            for (ijet, jet) in enumerate(selectedjets)
                 jet_output *= " $(ijet) - $(jet)\n"
             end
             "$(jet_output)"
         end
         if !isnothing(dump)
-            push!(jet_collection, FinalJets(ievt, final_jets(finaljets)))
+            push!(jet_collection, FinalJets(ievt, final_jets(selectedjets)))
         end
     end
 

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -12,6 +12,9 @@ julia --project instrumented-jetreco.jl --algorithm=CA -R 1.0 ../test/data/event
 echo "pp 14TeV Kt"
 julia --project instrumented-jetreco.jl --algorithm=Kt -R 1.0 ../test/data/events.pp13TeV.hepmc3.zst
 
+echo "pp 14TeV Kt with dump option"
+julia --project instrumented-jetreco.jl --algorithm=Kt -R 1.0 ../test/data/events.pp13TeV.hepmc3.zst --dump test-output-pp.csv
+
 echo "ee H Durham allocation test"
 julia --project instrumented-jetreco.jl --algorithm=Durham --alloc ../test/data/events.eeH.hepmc3.zst
 
@@ -21,3 +24,5 @@ julia --project jetreco.jl --algorithm=CA -R 1.0 ../test/data/events.pp13TeV.hep
 echo "ee basic reco test"
 julia --project jetreco.jl --algorithm=EEKt -R 1.0 -p -1.0 ../test/data/events.eeH.hepmc3.zst
 
+echo "ee basic reco test with dump"
+julia --project jetreco.jl --algorithm=EEKt -R 1.0 -p -1.0 ../test/data/events.eeH.hepmc3.zst --dump test-output-ee.csv


### PR DESCRIPTION
The `--dump` option for `jetreco.jl` and `instrumented-jetreco.jl` was broken because either variable declaration was missing or type conversion was missing

Closes #181 

@mattleblanc