### PR TITLE
Only plot histogram when possible

### DIFF
--- a/test/data/hepmc32summary.jl
+++ b/test/data/hepmc32summary.jl
@@ -50,7 +50,9 @@ function main()
             println("File $file")
             println("  Number of events: $n_events")
             println("  Average number of particles: ", mean(n_particles))
-            println(histogram(n_particles))
+            if n_events > 1
+                println(histogram(n_particles))
+            end
         end
     end
 end


### PR DESCRIPTION
Do not try to plot a histogram with less than 2 values (it crashes!).

Discovered when I ran over a HepMC3 file with just one event in it.