### PR TITLE
Improved softkiller examples

### DIFF
--- a/examples/softkiller/README.md
+++ b/examples/softkiller/README.md
@@ -1,23 +1,27 @@
 # JetReconstruction.jl Examples - SoftKiller
 
+Here are simple examples of SoftKiller that read from two HepMC3 files and
+then run the SoftKiller algorithm.
+
 ## `softkiller_plots.jl`
 
 This example can be run as:
 
 ```sh
-julia --project softkiller_plots.jl  --maxevents=100 --grid-size=0.4  --algorithm=Kt --pileup-file=../../test/data/sk_example_PU.hepmc.zst --hard-file=../../test/data/sk_example_HS.hepmc.zst
+julia --project softkiller_plots.jl --pileup-maxevents=100 --eventno=4 --grid-size=0.4 --algorithm=Kt ../../test/data/sk_example_HS.hepmc.zst ../../test/data/sk_example_PU.hepmc.zst
 ```
 
 This is a simple example of SoftKiller that reads from two HepMC3 files
-and displays plots of clustering without SoftKiller and with SoftKiller.
+and displays plots of clustering with SoftKiller and without SoftKiller.
 
 ## `softkiller_runtime.jl`
 
 This example can be run as:
 
 ```sh
-julia --project softkiller_runtime.jl  --maxevents=100 --grid-size=0.4  --algorithm=Kt --pileup-file=../../test/data/sk_example_PU.hepmc.zst --hard-file=../../test/data/sk_example_HS.hepmc.zst
+julia --project softkiller_runtime.jl --pileup-maxevents=100 --eventno=4 --grid-size=0.4 --algorithm=Kt ../../test/data/sk_example_HS.hepmc.zst ../../test/data/sk_example_PU.hepmc.zst
 ```
 
-This is a simple example of SoftKiller that reads from two HepMC3 files
-and displays the runtime of the SoftKiller algorithm.
+For both scripts the number of pileup events to add to the hard scatter event
+can be controlled with `--pileup-maxevents` and `--pileup-skip`; and the hard
+scatter event to work with can be changed with `--eventno`.

--- a/examples/softkiller/softkiller_plots.jl
+++ b/examples/softkiller/softkiller_plots.jl
@@ -12,15 +12,20 @@ include(joinpath(@__DIR__, "..", "parse-options.jl"))
 function parse_command_line(args)
     s = ArgParseSettings(autofix_names = true)
     @add_arg_table! s begin
-        "--maxevents", "-n"
-        help = "Maximum number of events to read. -1 to read all events from the  file."
+        "--pileup-maxevents", "-n"
+        help = "Maximum number of events to read. -1 to read all events from the pileup events file."
         arg_type = Int
         default = -1
 
-        "--skip", "-s"
-        help = "Number of events to skip at beginning of the file."
+        "--pileup-skip", "-s"
+        help = "Number of events to skip in the pileup events file."
         arg_type = Int
         default = 0
+
+        "--eventno", "-e"
+        help = "Event number to process from the hard scatter events file. If not specified, the first event will be processed."
+        arg_type = Int
+        default = 1
 
         "--ptmin"
         help = "Minimum p_t for final inclusive jets (energy unit is the same as the input clusters, usually GeV)"
@@ -53,19 +58,16 @@ function parse_command_line(args)
         arg_type = RecoStrategy.Strategy
         default = RecoStrategy.Best
 
-        "--dump"
-        help = "Write list of reconstructed jets to a JSON formatted file"
-
         "--grid-size"
         help = "Size of Rectangular grid"
         arg_type = Float64
         default = 0.4
 
-        "--hard-file"
+        "hard-file"
         help = "HepMC3 event file in HepMC3 to read."
         required = true
 
-        "--pileup-file"
+        "pileup-file"
         help = "HepMC3 event file in HepMC3 to read."
         required = true
     end
@@ -150,6 +152,7 @@ function plot_set_up(y::Vector{Float64}, phi::Vector{Float64}, pt::Vector{Float6
            ["Pileup", "Hard Event", "Jet"], "Legend")
 
     save(plot_title * ".png", fig)
+    @info "Plot '$(plot_title)' saved"
 end
 
 function main()
@@ -166,20 +169,17 @@ function main()
 
     # Reading pileup and hard event files
     events = read_final_state_particles(args[:pileup_file], jet_type;
-                                        maxevents = args[:maxevents],
-                                        skipevents = args[:skip])
+                                        maxevents = args[:pileup_maxevents],
+                                        skipevents = args[:pileup_skip])
 
     h_events = read_final_state_particles(args[:hard_file], jet_type;
-                                          maxevents = args[:maxevents],
-                                          skipevents = args[:skip])
+                                          maxevents = args[:eventno],
+                                          skipevents = args[:eventno])
 
     # Set up SoftKiller grid and rapidity range
     rapmax = 5.0
     grid_size = args[:grid_size]
     soft_killer = SoftKiller(rapmax, grid_size)
-
-    algorithm = args[:algorithm]
-    p = args[:power]
 
     # Ensure algorithm and power are consistent
     if isnothing(args[:algorithm]) && isnothing(args[:power])
@@ -205,8 +205,8 @@ function main()
         end
     end
 
-    # Fill hard event jets (from second event in h_events)
-    for pseudo_jet in h_events[2]
+    # Fill hard event jets (only the first event will be read)
+    for pseudo_jet in h_events[1]
         push!(hard_only, pseudo_jet)
         push!(all_jets_sk, pseudo_jet)
         push!(all_jets, pseudo_jet)
@@ -248,6 +248,7 @@ function main()
     pt_threshold = 0.00
     # Apply SoftKiller to all_jets_sk (hard + pileup)
     reduced_event, pt_threshold = softkiller(soft_killer, all_jets_sk)
+    @info "SoftKiller applied: $(length(reduced_event)) clusters remaining from $(length(all_jets_sk)), pt threshold = $pt_threshold"
 
     # Plot all PseudoJets after SoftKiller, before clustering
     y_all_sk, phi_all_sk, pt_all_sk,

--- a/examples/softkiller/test.sh
+++ b/examples/softkiller/test.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+# Plain softkiller example
+julia --project softkiller_runtime.jl --pileup-maxevents=100 --eventno=4 --grid-size=0.4 --algorithm=Kt ../../test/data/sk_example_HS.hepmc.zst ../../test/data/sk_example_PU.hepmc.zst
+
+# Softkiller with graphics
+julia --project softkiller_plots.jl --pileup-maxevents=100 --eventno=4 --grid-size=0.4 --algorithm=Kt ../../test/data/sk_example_HS.hepmc.zst ../../test/data/sk_example_PU.hepmc.zst


### PR DESCRIPTION
Rename `--maxevents` and `--skip` to `--pileup-maxevents` and `--pileup-skip` which allow variations in the amount of pileup to be applied.

Select the hard scatter event with `--eventno` (this only ever one event).

Change hard scatter and pileup files to be positional arguments, which is more consistent with other scripts.

Make both scripts a bit more verbose for the user's information.

Run a jet reconstruction in `softkiller_runtime.jl` so that we actually do something with the reduced event.

N.B. for now, the reduced event has to be rewritten into a new vector to get the `cluster_hist_index`es correct. This can be removed once softkiller returns a good-for-reconstruction output.

Add a `test.sh` script that can be used for a quick test of the examples.