### PR TITLE
Ignore profiles and some codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,6 @@ benchmark/*
 # Misc files
 .DS_Store
 /notebooks/*
-/profile/*
+**/profile/*
 /statprof/*
 /debug/*

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,11 @@
+# Ignore some of the untestable examples
+# until we can find a good way to handle
+# their heavy package dependencies
+ignore:
+  - "examples/constituents"
+  - "examples/EDM4hep"
+  - "examples/lundplane"
+  - "examples/softkiller"
+  - "examples/substructure"
+  - "examples/visualisation"
+  - "test/data"


### PR DESCRIPTION
Add all profile directories to gitignore, as we might profile in various places now

Add heavy examples to codecov ignore, as these can't be tested until we adopt Pkg workspaces
