### PR TITLE
Fix jet selector

### DIFF
--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -264,7 +264,7 @@ function inclusive_jets(clusterseq::ClusterSequence{U}; ptmin = 0.0,
                 push!(jets_local, jet)
             else
                 push!(jets_local,
-                      LorentzVectorCyl(pt(jet), rapidity(jet), phi(jet), mass(jet)))
+                      LorentzVectorCyl(pt(jet), eta(jet), phi(jet), mass(jet)))
             end
         end
     end
@@ -355,7 +355,7 @@ function exclusive_jets(clusterseq::ClusterSequence{U}; dcut = nothing, njets = 
                     push!(excl_jets, jet)
                 else
                     push!(excl_jets,
-                          LorentzVectorCyl(pt(jet), rapidity(jet), phi(jet), mass(jet)))
+                          LorentzVectorCyl(pt(jet), eta(jet), phi(jet), mass(jet)))
                 end
             end
         end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -125,7 +125,7 @@ function final_jets(jets::Vector{LorentzVectorCyl}, ptmin::AbstractFloat = 0.0)
         if LorentzVectorHEP.pt(jet)^2 > dcut
             count += 1
             push!(final_jets,
-                  FinalJet(LorentzVectorHEP.eta(jet), LorentzVectorHEP.phi(jet),
+                  FinalJet(LorentzVectorHEP.rapidity(jet), LorentzVectorHEP.phi(jet),
                            LorentzVectorHEP.pt(jet)))
         end
     end

--- a/test/_common.jl
+++ b/test/_common.jl
@@ -126,7 +126,7 @@ function run_reco_test(test::ComparisonTest; testname = nothing)
                         # the momentum
                         # Sometimes phi could be in the range [-π, π], but FastJet always is [0, 2π]
                         normalised_phi = jet.phi < 0.0 ? jet.phi + 2π : jet.phi
-                        @test jet.rap≈fastjet_jets[ievt]["jets"][ijet]["rap"] atol=1e-7
+                        @test jet.rap≈fastjet_jets[ievt]["jets"][ijet]["rap"] rtol=1e-6
                         @test normalised_phi≈fastjet_jets[ievt]["jets"][ijet]["phi"] atol=1e-7
                         @test jet.pt≈fastjet_jets[ievt]["jets"][ijet]["pt"] rtol=1e-6
                     end

--- a/test/test-jet-utils.jl
+++ b/test/test-jet-utils.jl
@@ -3,10 +3,10 @@
 include("common.jl")
 
 pj1 = PseudoJet(1.0, 1.3, -2.3, 25.0)
-pj2 = PseudoJet(1.0, 0.3, -1.3, 17.0)
+pj2 = PseudoJet(1.0, 0.3, 1.3, 17.0)
 
 eej1 = EEjet(1.0, 1.3, -2.3, 25.0)
-eej2 = EEjet(-1.0, 3.2, -1.2, 39.0)
+eej2 = EEjet(-1.0, 3.2, 1.2, 39.0)
 
 @testset "Common jet utilities" begin
     @test JetReconstruction.pt_fraction(pj1, pj2) ≈ 0.3889609897118418
@@ -19,8 +19,9 @@ eej2 = EEjet(-1.0, 3.2, -1.2, 39.0)
     @test jr_kt_scale ≈ lvhep_kt_scale
 
     # Accessors and utilities
-    @test JetReconstruction.rapidity(eej1) ≈ JetReconstruction.rapidity(pj1) ≈ -0.09226088885177856
-
+    @test JetReconstruction.rapidity(eej1) ≈ JetReconstruction.rapidity(pj1) ≈
+          -0.09226088885177856
+    @test JetReconstruction.rapidity(eej2) ≈ 0.030778946499716776
 
     # Test conversions
     lv_pj1 = JetReconstruction.lorentzvector(pj1)

--- a/test/test-jet-utils.jl
+++ b/test/test-jet-utils.jl
@@ -18,6 +18,10 @@ eej2 = EEjet(-1.0, 3.2, -1.2, 39.0)
                             JetReconstruction.lorentzvector_cyl(pj2))
     @test jr_kt_scale ≈ lvhep_kt_scale
 
+    # Accessors and utilities
+    @test JetReconstruction.rapidity(eej1) ≈ JetReconstruction.rapidity(pj1) ≈ -0.09226088885177856
+
+
     # Test conversions
     lv_pj1 = JetReconstruction.lorentzvector(pj1)
     lv_eej1 = JetReconstruction.lorentzvector(eej1)


### PR DESCRIPTION
Ensure the correct LorentzVectorCyl vector is returned from `exclusive_jets` and `inclusive_jets`.

Slightly relax tolerance for rapidity comparison, as some precision is lost in conversion back and forth.

This is the minimal fix for #197 