### PR TITLE
Update citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,6 +30,11 @@ identifiers:
 preferred-citation:
   type: article
   title: Polyglot Jet Finding
+  doi: 10.1051/epjconf/202429505017
+  journal: EPJ Web Conf.
+  volume: 295
+  start: "05017"
+  year: 2024
   authors:
     - given-names: Graeme Andrew
       family-names: Stewart
@@ -49,9 +54,6 @@ preferred-citation:
       email: benedikt.hegner@cern.ch
       affiliation: CERN
       orcid: 'https://orcid.org/0009-0009-2020-1620'
-  identifiers:
-    - type: doi
-      value: 10.1051/epjconf/202429505017
 repository-code: 'https://github.com/JuliaHEP/JetReconstruction.jl'
 abstract: Jet reconstruction (reclustering) with Julia
 license: MIT

--- a/README.md
+++ b/README.md
@@ -130,13 +130,17 @@ conference proceedings, [arXiv:2309.17309](https://arxiv.org/abs/2309.17309),
 should be cited if you use this package:
 
 ```bibtex
-@misc{stewart2023polyglot,
-      title={Polyglot Jet Finding}, 
-      author={Graeme Andrew Stewart and Philippe Gras and Benedikt Hegner and Atell Krasnopolski},
-      year={2023},
-      eprint={2309.17309},
-      archivePrefix={arXiv},
-      primaryClass={hep-ex}
+@article{Stewart:2023lgt,
+    author = "Stewart, Graeme Andrew and Gras, Philippe and Hegner, Benedikt and Krasnopolski, Atell",
+    title = "{Polyglot Jet Finding}",
+    eprint = "2309.17309",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    doi = "10.1051/epjconf/202429505017",
+    journal = "EPJ Web Conf.",
+    volume = "295",
+    pages = "05017",
+    year = "2024"
 }
 ```
 


### PR DESCRIPTION
The "Polyglot Jet Finding" article is now published so it can be cited instead of a pre-print. (updated BibTex taken from inspirehep)

The citation generated from GitHub "cite this repository" is very minimal and in particular misses data with respect to the one from README:
```
@article{Stewart_Polyglot_Jet_Finding,
author = {Stewart, Graeme Andrew and Krasnopolski, Atell and Gras, Philippe and Hegner, Benedikt},
title = {{Polyglot Jet Finding}}
}
```

After update and change it should give something that is very close to BibTeX from inspirehep or publisher:
```
@article{Stewart_Polyglot_Jet_Finding_2024,
author = {Stewart, Graeme Andrew and Krasnopolski, Atell and Gras, Philippe and Hegner, Benedikt},
doi = {10.1051/epjconf/202429505017},
journal = {EPJ Web Conf.},
pages = {05017},
title = {{Polyglot Jet Finding}},
volume = {295},
year = {2024}
}
```

