### PR TITLE
consistently use `isnothing`

### DIFF
--- a/examples/parse-options.jl
+++ b/examples/parse-options.jl
@@ -6,12 +6,12 @@ Add `parse_item` code for interpreting `JetAlgorithm.Algorithm` and
 function do_enum_parse(E::Type, x::AbstractString)
     insts = instances(E)
     p = findfirst(==(Symbol(x)) ∘ Symbol, insts)
-    p !== nothing ? insts[p] : nothing
+    !isnothing(p) ? insts[p] : nothing
 end
 
 function ArgParse.parse_item(E::Type{JetAlgorithm.Algorithm}, x::AbstractString)
     p = do_enum_parse(E, x)
-    if p === nothing
+    if isnothing(p)
         throw(ErrorException("Invalid value for algorithm: $(x)"))
     end
     p
@@ -19,7 +19,7 @@ end
 
 function ArgParse.parse_item(E::Type{RecoStrategy.Strategy}, x::AbstractString)
     p = do_enum_parse(E, x)
-    if p === nothing
+    if isnothing(p)
         throw(ErrorException("Invalid value for strategy: $(x)"))
     end
     p
@@ -27,7 +27,7 @@ end
 
 function ArgParse.parse_item(E::Type{RecombinationScheme.Recombine}, x::AbstractString)
     p = do_enum_parse(E, x)
-    if p === nothing
+    if isnothing(p)
         throw(ErrorException("Invalid value for recombination scheme: $(x)"))
     end
     p

--- a/src/EEAlgorithm.jl
+++ b/src/EEAlgorithm.jl
@@ -354,7 +354,7 @@ function ee_genkt_algorithm(particles::AbstractVector{T}; algorithm::JetAlgorith
                             preprocess = preprocess_escheme) where {T}
 
     # For Valencia, if β is provided, overwrite p
-    if algorithm === JetAlgorithm.Valencia && β !== nothing
+    if algorithm === JetAlgorithm.Valencia && !isnothing(β)
         p = β
     end
 


### PR DESCRIPTION
Code churn :sweat_smile:  Replaces `=== nothing` with `isnothing`. This is done mostly for consistency as currently there are more than 40 calls to `isnothing` and only 5 to `=== nothing`.
