### PR TITLE
test with `pre` instead of `nightly` in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
         version:
           - 'lts'
           - '1'
-          - 'nightly'
+          - 'pre'
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ updating too.** This is easy to miss and the failure shows up late.
 
 ### Julia version floor
 
-`[compat]` sets `julia = "1.10"`, and CI runs `lts`, `1` and `nightly` on both
+`[compat]` sets `julia = "1.10"`, and CI runs `lts`, `1` and `pre` on both
 x64 and aarch64. **Do not use language features newer than 1.10.** A
 `Downgrade compat` workflow additionally tests against the lowest permitted
 version of every dependency, so do not rely on behaviour newer than the


### PR DESCRIPTION
I don't think we are that much of a bleeding edge to be concerned with nightlies, while some of the (optional) dependencies we have are quite fragile (CxxWrap) - anyway hopefully they will be fixed for release candidates which also give us information whether our code is expected to work in a future or not